### PR TITLE
add gem groups for dev / production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source "https://rubygems.org"
 
 gem "lita"
-gem "lita-slack"
+
+group :production do
+  gem "lita-slack"
+end
 
 # Uncomment to use the IRC adapter
 # gem "lita-irc"
@@ -20,5 +23,8 @@ gem "lita-pugbomb"
 gem "lita-flip"
 gem "lita-cron"
 
-gem 'pry'
 gem "httparty"
+
+group :development do
+  gem 'pry'
+end

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Requires Ruby & Redis, http://docs.lita.io/getting-started/installation/#manual-
 
 `lita start` runs lita based on the current config.
 
-To get a local console for testing development:
-
-1. Comment out the `gem "lita-slack"` line in Gemfile and re-run `bundle install`
- + Then slack gem needs an token env var token so won't start without a valid one (see lita_config.rb).
-2. Change `lita_config.rb` line `config.robot.adapter = :slack` to `config.robot.adapter = :shell` http://docs.lita.io/getting-started/usage/#shell-adapter
-
 Once done you can run the `lita start` command as above and get a lita shell.
 Then go ahead and use lita commands from the shell for testing, e.g. `lita project galaxy` to run the `lita-zooniverse-projects` plugin.
+
+## Production
+Set the LITA_ENV variable to run in production mode on start `LITA_ENV=production lita start`.
+
+Note: If running in production mode then slack gem needs an token env var token
+and won't start without a valid one (see lita_config.rb).

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -1,3 +1,18 @@
+require 'bundler'
+
+module Lita
+  def self.env
+    ENV["LITA_ENV"] || :development
+  end
+
+  def self.env?(env=:development)
+    self.env == env
+  end
+end
+
+Bundler.require(:default, Lita::env)
+
+
 $:.unshift(File.expand_path("lita-zooniverse-projects/lib", File.dirname(__FILE__)))
 puts $:.inspect
 
@@ -18,12 +33,14 @@ Lita.configure do |config|
   # What is considered a user ID will change depending on which adapter you use.
   # config.robot.admins = ["1", "2"]
 
-  # The adapter you want to connect with. Make sure you've added the
-  # appropriate gem to the Gemfile.
-  config.robot.adapter = :slack
+  if Lita::env?(:production)
+    # The adapter you want to connect with. Make sure you've added the
+    # appropriate gem to the Gemfile.
+    config.robot.adapter = :slack
 
-  ## Example: Set options for the chosen adapter.
-  config.adapters.slack.token = ENV["SLACK_TOKEN"]
+    ## Example: Set options for the chosen adapter.
+    config.adapters.slack.token = ENV["SLACK_TOKEN"]
+  end
 
   ## Example: Set options for the Redis connection.
   # config.redis.host = "127.0.0.1"


### PR DESCRIPTION
possible solution for the gem requires when working in dev / production mode. turns out lita defaults to a shell without a config.