### PR TITLE
report legacy zooniverse id for migrated legacy projects

### DIFF
--- a/lita-zooniverse/lib/lita-zooniverse.rb
+++ b/lita-zooniverse/lib/lita-zooniverse.rb
@@ -4,6 +4,16 @@ Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__
 )]
 
+module Lita
+  def self.env
+    ENV["LITA_ENV"] || :development
+  end
+
+  def self.env?(env=:development)
+    self.env.to_s == env.to_s
+  end
+end
+
 require "lita/handlers/projects"
 require "lita/handlers/deployment"
 require "lita/handlers/reload"

--- a/lita-zooniverse/lib/lita-zooniverse.rb
+++ b/lita-zooniverse/lib/lita-zooniverse.rb
@@ -4,16 +4,6 @@ Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__
 )]
 
-module Lita
-  def self.env
-    ENV["LITA_ENV"] || :development
-  end
-
-  def self.env?(env=:development)
-    self.env.to_s == env.to_s
-  end
-end
-
 require "lita/handlers/projects"
 require "lita/handlers/deployment"
 require "lita/handlers/reload"

--- a/lita-zooniverse/lib/lita/api/ouroboros_project.rb
+++ b/lita-zooniverse/lib/lita/api/ouroboros_project.rb
@@ -6,40 +6,44 @@ module Lita
 
       include Api::Project
 
-      def projects
-        project_names = find_project_names
-        return project_names if project_names.empty?
-        projects_search(project_names).map do |project|
-          "(O): #{project["bucket_path"]} -- #{project["zooniverse_id"]} -- #{project["display_name"]} "\
-          "(classifications: #{project["classification_count"]}, "\
-          "classifiers: #{project["user_count"]}, completed_subjects: #{project["complete_count"]})"
-	      end
+      def self.api_headers
+        {
+          "Content-Type" => "application/json",
+          "Accept" => "application/json"
+        }
       end
 
-      private
-
-      def api_host(project_name)
-        @api_host = "https://api.zooniverse.org/projects/#{project_name}"
-      end
-
-      def api_host_projects
-        @api_host_projects ||= "https://api.zooniverse.org/projects/list"
-      end
-
-      def projects_search(project_names)
+      def self.projects_search(project_names)
         project_names.map do |name|
-          HTTParty.get(api_host(name), { headers: api_headers })
+          api_host = "https://api.zooniverse.org/projects/#{name}"
+          HTTParty.get(api_host, { headers: api_headers })
         end
       end
 
-      def find_project_names
+      def self.find_project_names(search_query)
         all_projects = HTTParty.get(api_host_projects, { headers: api_headers })
         projects = all_projects.select do |project|
           [ project["display_name"], project["name"] ].any? do |name|
-            name.match(/\A(#{search_query.join(",")}).+/i)
+            name.match(/(#{search_query.join(",")})/i)
           end
         end
         projects.map{ |p| p["name"] }
+      end
+
+      def self.projects(search_query)
+        project_names = find_project_names(search_query)
+        return project_names if project_names.empty?
+        projects_search(project_names).map { |project| self.new(project) }
+      end
+
+      def self.api_host_projects
+        @api_host_projects ||= "https://api.zooniverse.org/projects/list"
+      end
+
+      def to_s
+        "(O): #{project["bucket_path"]} -- #{project["zooniverse_id"]} -- #{project["display_name"]} "\
+        "(classifications: #{project["classification_count"]}, "\
+        "classifiers: #{project["user_count"]}, completed_subjects: #{project["complete_count"]})"
       end
     end
   end

--- a/lita-zooniverse/lib/lita/api/panoptes_project.rb
+++ b/lita-zooniverse/lib/lita/api/panoptes_project.rb
@@ -6,30 +6,42 @@ module Lita
 
       include Api::Project
 
-      def projects
-        results = JSON.parse(projects_search)
-        results["projects"].map do |project|
-          next if project["migrated"]
-          "(P): #{project_url(project)} -- #{project["id"]} -- #{project["display_name"]} (classifications: #{project["classifications_count"]}, classifiers: #{project["classifiers_count"]}, live: #{project["live"]})"
-	      end.compact
+      def self.api_headers
+        {
+          "Content-Type" => "application/json",
+          "Accept" => "application/vnd.api+json; version=1"
+        }
+      end
+
+      def self.api_host
+        @api_host ||= "https://www.zooniverse.org/api/projects"
+      end
+
+      def self.projects(search_query)
+        projects = HTTParty.get(api_host, { headers: api_headers, query: { search: search_query } })
+        results = JSON.parse(projects)
+        results["projects"].map { |project| self.new(project) }.compact
+      end
+
+      def to_s
+        "(P): #{project_url(project)} -- #{project["id"]} -- #{project["display_name"]} "\
+        "(classifications: #{project["classifications_count"]}, "\
+        "classifiers: #{project["classifiers_count"]}, live: #{project["live"]}"\
+        "#{migrated? ? ", zoo_project_id: #{legacy_zoo_project_id}" : ""})"
       end
 
       private
 
-      def api_host
-        @api_host ||= "https://www.zooniverse.org/api/projects"
-      end
-
-      def projects_search
-        HTTParty.get(api_host, { headers: api_headers, query: { search: search_query } })
+      def migrated?
+        project["migrated"]
       end
 
       def project_url(project)
         "https://www.zooniverse.org/projects/#{project["slug"]}"
       end
 
-      def api_headers
-        super.merge("Accept" => "application/vnd.api+json; version=1")
+      def legacy_zoo_project_id
+        project["configuration"]["zoo_home_project_id"]
       end
     end
   end

--- a/lita-zooniverse/lib/lita/api/project.rb
+++ b/lita-zooniverse/lib/lita/api/project.rb
@@ -4,16 +4,14 @@ module Lita
   module Api
     module Project
 
-      attr_reader :search_query
+      attr_reader :project
 
-      def initialize(search_query)
-        @search_query = search_query
+      def initialize(project)
+        @project = project
       end
 
-      private
-
-      def api_headers
-        {"Content-Type" => "application/json", "Accept" => "application/json"}
+      def to_s
+        raise NotImplementedError.new
       end
     end
   end

--- a/lita-zooniverse/lib/lita/handlers/deployment.rb
+++ b/lita-zooniverse/lib/lita/handlers/deployment.rb
@@ -1,6 +1,7 @@
 require 'httparty'
 require 'octokit'
 require 'jenkins_api_client'
+require_relative '../../../../lita_env'
 
 module Lita
   module Handlers

--- a/lita-zooniverse/lib/lita/handlers/deployment.rb
+++ b/lita-zooniverse/lib/lita/handlers/deployment.rb
@@ -10,8 +10,8 @@ module Lita
       RAKE_JOB   = "Run rake task"
 
       config :jenkins_url, default: 'https://jenkins.zooniverse.org'
-      config :jenkins_username, required: true
-      config :jenkins_password, required: true
+      config :jenkins_username, required: Lita::env?(:production)
+      config :jenkins_password, required: Lita::env?(:production)
 
       route(/^panoptes (status|version)/, :status, command: true, help: {"panoptes status" => "Returns the number of commits not deployed to production."})
       route(/^panoptes build/, :build, command: true, help: {"panoptes build" => "Triggers a build of a new AMI of *PRODUCTION* in Jenkins."})

--- a/lita-zooniverse/lib/lita/handlers/projects.rb
+++ b/lita-zooniverse/lib/lita/handlers/projects.rb
@@ -9,9 +9,8 @@ module Lita
 
       def project(response)
         search = response.matches[0]
-        projects = Api::OuroborosProject.new(search).projects
-        projects << Api::PanoptesProject.new(search).projects
-        projects.flatten!
+        projects = Api::OuroborosProject.projects(search).map(&:to_s)
+        projects << Api::PanoptesProject.projects(search).map(&:to_s)
 
         if projects.size > 0
           response.reply(projects.join("\n"))

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -1,14 +1,5 @@
 require 'bundler'
-
-module Lita
-  def self.env
-    ENV["LITA_ENV"] || :development
-  end
-
-  def self.env?(env=:development)
-    self.env.to_s == env.to_s
-  end
-end
+require_relative 'lita-zooniverse/lib/lita-zooniverse'
 
 Bundler.require(:default, Lita::env)
 Dotenv.load
@@ -47,5 +38,3 @@ Lita.configure do |config|
   config.handlers.deployment.jenkins_username = ENV["JENKINS_USERNAME"]
   config.handlers.deployment.jenkins_password = ENV["JENKINS_PASSWORD"]
 end
-
-require_relative 'lita-zooniverse/lib/lita-zooniverse'

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -1,5 +1,4 @@
 require 'bundler'
-require_relative 'lita-zooniverse/lib/lita-zooniverse'
 
 Bundler.require(:default, Lita::env)
 Dotenv.load
@@ -38,3 +37,5 @@ Lita.configure do |config|
   config.handlers.deployment.jenkins_username = ENV["JENKINS_USERNAME"]
   config.handlers.deployment.jenkins_password = ENV["JENKINS_PASSWORD"]
 end
+
+require_relative 'lita-zooniverse/lib/lita-zooniverse'

--- a/lita_env.rb
+++ b/lita_env.rb
@@ -1,0 +1,9 @@
+module Lita
+  def self.env
+    ENV["LITA_ENV"] || :development
+  end
+
+  def self.env?(env=:development)
+    self.env.to_s == env.to_s
+  end
+end


### PR DESCRIPTION
closes #4, allow the user to decide which projects are migrated by showing the legacy id's. 

Also allow dev env not to need jenkins env vars and refactored to static contexts for search and then string representation to instance methods.