### PR TITLE
update panoptes update tag job

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -32,7 +32,7 @@ module Lita
       route(/^(status|build|migrate|deploy|lock|unlock)/, :reversed, command: true)
 
       route(/^panoptes (status|version)/, :status, command: true, help: {"panoptes status" => "Returns the number of commits not deployed to production."})
-      route(/^(panoptes) update tag/, :update_tag, command: true, help: {"panoptes update tag" => "Triggers a GitHub production tag update via Jenkins."})
+      route(/^(panoptes) update tag(\sand build)?$/, :update_tag, command: true, help: {"panoptes update tag" => "Triggers a GitHub production tag update via Jenkins, in turn dockerhub & Jenkins will build a new production AMI."})
       route(/^(panoptes) build/, :build, command: true, help: {"panoptes build" => "Triggers a build of a new AMI of *PRODUCTION* in Jenkins."})
       route(/^(panoptes) migrate/, :migrate, command: true, help: {"panoptes migrate" => "Runs database migrations for Panoptes *PRODUCTION* in Jenkins."})
       route(/^(panoptes) deploy$/, :deploy, command: true, help: {"panoptes deploy" => "Triggers a deployment of *PRODUCTION* in Jenkins."})


### PR DESCRIPTION
docker hub production tag will now auto build a new production ami via jenkins web hook that reflects on the incoming tag name (production). 

no need to run update tag, wait and check docker hub and then build. this should all happen naturally now.