### PR TITLE
add libssl-dev to ensure event machine works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG LITA_ENV
 ENV PORT=80
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git supervisor && \
+    apt-get install --no-install-recommends -y git supervisor libssl-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ADD ./Gemfile /app/


### PR DESCRIPTION
seems the openssl libs are missing bits that event machine uses to correctly build for newer TLS versions, using libssl-dev installed the same underlying library but when a rebuilt event machine now connects securely. Ideally this is taken care of by the underlying ruby build vs a manual dev package install. 

Moving to a new ruby build may be the best way to fix the problem, if so remove / revert this dependency addition.