### PR TITLE
Remove Caesar short-circuit for k8s migration

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -17,9 +17,6 @@ module Lita
           deploy_api_only: "Deploy latest Panoptes Production API only build",
           update_tag: "Update panoptes production tag"
         },
-        "caesar" => {
-          deploy: "Update Caesar Production"
-        },
         "stats" => {
           deploy: "Update Zoo Event Stats production"
         },


### PR DESCRIPTION
Merge only when Caesar is in the cluster and is using the `production-release` tag for production deployment.