### PR TITLE
use the tested ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3
+FROM ruby:2.4
 WORKDIR /app
 ARG LITA_ENV
 ENV PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4
+FROM ruby:2.6
 WORKDIR /app
 ARG LITA_ENV
 ENV PORT=80


### PR DESCRIPTION
bump ruby version to 2.6
we're currently testing on ruby 2.4 only but we're running on 2.3 via docker