### PR TITLE
generalize status command for k8s apps

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -146,6 +146,9 @@ module Lita
 
       def status(response)
         repo_name = response.matches[0][1]
+        unless repo_name.match(/\Azooniverse\/.*/)
+          repo_name = "zooniverse/#{repo_name}"
+        end
         response.reply(
           get_repo_status(repo_name)
         )

--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -74,7 +74,7 @@ module Lita
       # state: the default deploy "chat ops" deploy system
       #        and in use for all K8s deployed services
       route(/^(deploy)\s*(.*)/, :tag_deploy, command: true, help: {"deploy REPO" => "Updates the production-release tag on zooniverse/REPO"})
-      route(/^(status|version)\s*(.*)/, :status, command: true, help: {'status REPO_NAME' => 'Returns the number of state of commits not deployed for the $REPO_NAME.'})
+      route(/^(status|version)\s*(.*)/, :status, command: true, help: {'status REPO_NAME' => 'Returns the state of commits not deployed for the $REPO_NAME.'})
 
       def run_deployment_task(response, job)
         app, jobs = get_jobs(response)

--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -74,7 +74,7 @@ module Lita
       # state: the default deploy "chat ops" deploy system
       #        and in use for all K8s deployed services
       route(/^(deploy)\s*(.*)/, :tag_deploy, command: true, help: {"deploy REPO" => "Updates the production-release tag on zooniverse/REPO"})
-      route(/^(status|version)\s*(.*)/, :status, command: true, help: {'status GITHUB_ORG/REPO_NAME' => 'Returns the number of commits not deployed to production-release for the org/repo_name.'})
+      route(/^(status|version)\s*(.*)/, :status, command: true, help: {'status REPO_NAME' => 'Returns the number of state of commits not deployed for the $REPO_NAME.'})
 
       def run_deployment_task(response, job)
         app, jobs = get_jobs(response)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,12 @@ if ENV["REDIS_HOST"]
   end
 end
 
+if ENV["REDIS_HOST"]
+  Lita.configure do |config|
+    config.redis[:host] = ENV["REDIS_HOST"]
+  end
+end
+
 $:.unshift(File.expand_path("../../handlers", __FILE__))
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,6 @@ if ENV["REDIS_HOST"]
   end
 end
 
-if ENV["REDIS_HOST"]
-  Lita.configure do |config|
-    config.redis[:host] = ENV["REDIS_HOST"]
-  end
-end
-
 $:.unshift(File.expand_path("../../handlers", __FILE__))
 
 # A compatibility mode is provided for older plugins upgrading from Lita 3. Since this plugin


### PR DESCRIPTION
1. Allow docker to be used for testing / developing handlers for lita app. 
2. Also use docker compose testing via travis for consistency between our environments
3. Add a generalised deployed status cmd to lita (similar to `lita deploy $REPO` e.g. `lita status zooniverse/zoo-stats-api-graphql`)

This PR needs to be rebased over #62 once that is in.