### PR TITLE
remove martens bucket lita handlers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "lita-applause"
 gem "lita-pugbomb"
 gem "lita-flip"
 gem "lita-cron"
-gem 'lita-bucket', git: 'https://github.com/marten/lita-bucket.git'
 
 gem "httparty"
 gem "octokit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/marten/lita-bucket.git
-  revision: b4f9667560eb64e7aff2564775ada1afbdeaa65c
-  specs:
-    lita-bucket (0.1.0)
-      a_vs_an
-      lita (>= 4.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -177,7 +169,6 @@ DEPENDENCIES
   lita
   lita-applause
   lita-baby_elephant
-  lita-bucket!
   lita-catfacts
   lita-catgif
   lita-cron
@@ -193,4 +184,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.0
+   1.17.2


### PR DESCRIPTION
removing this as we don't use the functionality, i'll leave the data in redis namespace `handlers:bucket` in case we want to restore this functionality at some stage. 

Also this is a security vector as this is a git repo and not a published gem (slightly easier to get commit rights to the repo vs a gem). 