### PR TITLE
Add loading lita handler spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .env
 data/redis/*
 vendor/*
+.DS_Store

--- a/lita_config.rb
+++ b/lita_config.rb
@@ -1,15 +1,7 @@
 require 'bundler'
 require_relative './lita_env'
 
-require_relative 'handlers/aws_handler'
-require_relative 'handlers/beverage_handler'
-require_relative 'handlers/dad_handler'
-require_relative 'handlers/deployment'
-require_relative 'handlers/insult_handler'
-require_relative 'handlers/lintott'
-require_relative 'handlers/projects'
-require_relative 'handlers/tell_handler'
-require_relative 'handlers/project_name_handler'
+require_relative './load_handlers'
 
 Bundler.require(:default, Lita::env)
 Dotenv.load(ENV["DOTENV_FILE"] || '.env')

--- a/load_handlers.rb
+++ b/load_handlers.rb
@@ -1,0 +1,8 @@
+require_relative 'handlers/aws_handler'
+require_relative 'handlers/dad_handler'
+require_relative 'handlers/deployment'
+require_relative 'handlers/insult_handler'
+require_relative 'handlers/lintott'
+require_relative 'handlers/projects'
+require_relative 'handlers/tell_handler'
+require_relative 'handlers/project_name_handler'

--- a/spec/load_handlers_spec.rb
+++ b/spec/load_handlers_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe 'load_handlers.rb' do
+  it 'does not error loading all handlers' do
+    expect { require_relative '../load_handlers'}.not_to raise_error
+  end
+end


### PR DESCRIPTION
add test coverage to ensure we test the lita handler file loading on boot. 

Linked to #76 as that forgot to remove the handler from `lita_config.rb` and broke the app