### PR TITLE
Add lita status all cmd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       - "LITA_ENV=development"
       - "REDIS_HOST=redis"
+      - "LANG=en"
     links:
       - redis:redis
 

--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -173,7 +173,6 @@ module Lita
       ensure
         if error_response
           # remove the repo from our tracking set for status all reports
-          binding.pry
           redis.zrem(DEPLOY_REPOS_SET_NAME, repo_name)
           error_response
         else

--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -4,37 +4,23 @@ require 'httparty'
 require 'octokit'
 require 'jenkins_api_client'
 require 'uri'
+require_relative '../lib/github_status_reporter'
 
 module Lita
   module Handlers
     class Deployment < Handler
-      class UnknownStatusResponseKey < StandardError; end
-      class MissingStatusResponse < StandardError; end
-      class MissingStatusResponseData < StandardError; end
-      class UnknownServiceUrl < StandardError; end
 
       JOBS = {
         "deploy" => "Update production-release tag",
         "migrate" => "Update production-migrate tag"
       }
 
-      IRREGULAR_ORG_URLS = {
-        'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
-        'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',
-        'zooniverse/zoo-event-stats' => 'https://stats.zooniverse.org/'
-      }.freeze
-
-      JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze
-      DEPLOYED_BRANCH_REPOS = {
-        'zooniverse/talk-api' => 'production',
-        'zooniverse/zoo-stats-api-graphql' => 'master'
-      }.freeze
-
       DEPLOY_REPOS_SET_NAME = 'deploy-repos'
 
       config :jenkins_url, default: 'https://jenkins.zooniverse.org'
       config :jenkins_username, required: Lita.required_config?
       config :jenkins_password, required: Lita.required_config?
+      config :github_status_reporter, default: Github::StatusReporter.new
 
       # THIS CAN GO
       route(/^(build)/, :reversed, command: true)
@@ -93,10 +79,10 @@ module Lita
 
         # Track in redis sorted set which systems we are deploying
         # note: this might track some false positives
-        #       these will be removed in the `get_repo_status` method on lookup failure
+        #       these will be removed in error handling via status_response
         redis.zadd(DEPLOY_REPOS_SET_NAME, 1, repo_name, incr: true)
 
-        build_jenkins_job(response, jenkins_job_name, { 'REPO' => repo_name })
+        # build_jenkins_job(response, jenkins_job_name, { 'REPO' => repo_name })
       end
 
       def tag_migrate(response)
@@ -106,14 +92,14 @@ module Lita
 
       def status(response)
         repo_name = response.matches[0][1]
-        response.reply(get_repo_status(repo_name))
+        response.reply(status_response(repo_name))
       end
 
       def status_all(response)
         output = []
         repos_sorted_to_deploy_frequency = redis.zrevrange(DEPLOY_REPOS_SET_NAME, 0, -1)
         repos_sorted_to_deploy_frequency.each do |repo_name|
-          output << "#{repo_name}\n#{get_repo_status(repo_name)}\n"
+          output << "#{repo_name}\n#{status_response(repo_name)}\n"
         end
         response.reply(output.join("\n"))
       end
@@ -152,106 +138,13 @@ module Lita
                                             ssl: true)
       end
 
-      def get_repo_status(repo_name)
-        unless repo_name.match(/\Azooniverse\/.*/)
-          repo_name = "zooniverse/#{repo_name}"
-        end
-        repo_url = repo_type_and_url(repo_name)
-        deployed_version = get_deployed_commit(repo_url)
-        production_tag = production_release_tag(repo_name)
-        good_response = get_app_status(repo_name, deployed_version, production_tag)
-      rescue UnknownServiceUrl
-        error_response = status_error_response('No service is running on the url', repo_url)
-      rescue MissingStatusResponse
-        error_response = status_error_response('Missing deployed status data on the service url', repo_url)
-      rescue MissingStatusResponseData
-        error_response = status_error_response('Deployed status found on the service url but it has no data', repo_url)
-      rescue UnknownStatusResponseKey
-        error_response = status_error_response('Unknown commit identifier in the status response body', repo_url)
-      rescue Octokit::NotFound
-        error_response = status_error_response('Unknown deploy branch / tag target on the repo', repo_url)
-      ensure
-        if error_response
+      def status_response(repo_name)
+        gh_status_response = config.github_status_reporter.get_repo_status(repo_name)
+        if gh_status_response.status == :error
           # remove the repo from our tracking set for status all reports
           redis.zrem(DEPLOY_REPOS_SET_NAME, repo_name)
-          error_response
-        else
-          good_response
         end
-      end
-
-      def status_error_response(msg, repo_url, error_prefix='Failed to fetch the deployed commit for this repo.')
-        "#{error_prefix}\n#{msg} - #{repo_url}"
-      end
-
-      def get_app_status(repo_name, deployed_version, prod_tag)
-        git_responses = {}
-        ['HEAD', prod_tag].each do |tag|
-          comparison = Octokit.compare(repo_name, deployed_version.strip, tag)
-          if comparison.commits.empty?
-            git_responses[tag] = 'is the currently deployed version.'
-          else
-            word = comparison.commits.size > 1 ? 'commits' : 'commit'
-            git_responses[tag] = "#{comparison.commits.size} undeployed #{word}. #{comparison.permalink_url}"
-            git_responses[tag] + ' :shipit:' if tag == 'production-release'
-          end
-        end
-
-        formatted_response = git_responses.map do |tag, comment|
-          "#{tag.upcase} : #{comment}"
-        end
-
-        formatted_response.join("\n")
-      end
-
-      def get_deployed_commit(repo_url)
-        deployed_status_data = fetch_deployed_status_data(repo_url)
-
-        # if the response object looks like a json object
-        if deployed_status_data.respond_to?(:keys)
-          commit_key = (JSON_COMMIT_ID_KEYS & deployed_status_data.keys).first
-          status_data = deployed_status_data.fetch(commit_key)
-          raise MissingStatusResponseData unless status_data
-
-          status_data
-        else
-          deployed_status_data
-        end
-      rescue KeyError
-        raise UnknownStatusResponseKey
-      end
-
-      def repo_type_and_url(repo_name)
-        url = IRREGULAR_ORG_URLS[repo_name]
-        if url
-          url
-        else
-          app_name = repo_name.split('/')[1]
-          "https://#{app_name}.zooniverse.org"
-        end
-      end
-
-      def production_release_tag(repo_name)
-        if branch_or_tag = DEPLOYED_BRANCH_REPOS[repo_name]
-          branch_or_tag
-        else
-          'production-release'
-        end
-      end
-
-      def fetch_deployed_status_data(repo_url)
-        # try the commit_id file first
-        repo_commit_id_url = "#{repo_url}/commit_id.txt"
-        repo_url_data = HTTParty.get(repo_commit_id_url)
-        if repo_url_data.code == 404
-          # let's try the root service url for some json data
-          repo_url_data = HTTParty.get(repo_url)
-        end
-        raise MissingStatusResponse if repo_url_data.code == 404
-
-        repo_url_data
-      rescue SocketError
-        raise UnknownServiceUrl
+        gh_status_response.body
       end
 
       Lita.register_handler(self)

--- a/kubernetes/deployment.tmpl
+++ b/kubernetes/deployment.tmpl
@@ -37,6 +37,8 @@ spec:
           env:
           - name: REDIS_HOST
             value: "lita-redis"
+          - name: LANG
+            value: "en"
           volumeMounts:
           - name: lita-environment
             mountPath: "/run/secrets/environment"

--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'ostruct'
+
+module Lita
+  module Github
+    class StatusReporter
+
+      class UnknownStatusResponseKey < StandardError; end
+      class MissingStatusResponse < StandardError; end
+      class MissingStatusResponseData < StandardError; end
+      class UnknownServiceUrl < StandardError; end
+
+      IRREGULAR_ORG_URLS = {
+        'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
+        'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',
+        'zooniverse/zoo-event-stats' => 'https://stats.zooniverse.org/'
+      }.freeze
+
+      JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze
+      DEPLOYED_BRANCH_REPOS = {
+        'zooniverse/talk-api' => 'production',
+        'zooniverse/zoo-stats-api-graphql' => 'master'
+      }.freeze
+
+      def get_repo_status(repo_name)
+        unless repo_name.match(/\Azooniverse\/.*/)
+          repo_name = "zooniverse/#{repo_name}"
+        end
+        repo_url = repo_type_and_url(repo_name)
+        deployed_version = get_deployed_commit(repo_url)
+        production_tag = production_release_tag(repo_name)
+        OpenStruct.new(
+          status: :ok,
+          body: get_app_status(repo_name, deployed_version, production_tag)
+        )
+      rescue UnknownServiceUrl
+        OpenStruct.new(
+          status: :error,
+          body: status_error_response('No service is running on the url', repo_url)
+        )
+      rescue MissingStatusResponse
+        OpenStruct.new(
+          status: :error,
+          body: status_error_response('Missing deployed status data on the service url', repo_url)
+        )
+      rescue MissingStatusResponseData
+        OpenStruct.new(
+          status: :error,
+          body: status_error_response('Deployed status found on the service url but it has no data', repo_url)
+        )
+      rescue UnknownStatusResponseKey
+        OpenStruct.new(
+          status: :error,
+          body: status_error_response('Unknown commit identifier in the status response body', repo_url)
+        )
+      rescue Octokit::NotFound
+        OpenStruct.new(
+          status: :error,
+          body: status_error_response('Unknown deploy branch / tag target on the repo', repo_url)
+        )
+      end
+
+      private
+
+      def status_error_response(msg, repo_url, error_prefix='Failed to fetch the deployed commit for this repo.')
+        "#{error_prefix}\n#{msg} - #{repo_url}"
+      end
+
+      def get_app_status(repo_name, deployed_version, prod_tag)
+        git_responses = {}
+        ['HEAD', prod_tag].each do |tag|
+          comparison = Octokit.compare(repo_name, deployed_version.strip, tag)
+          if comparison.commits.empty?
+            git_responses[tag] = 'is the currently deployed version.'
+          else
+            word = comparison.commits.size > 1 ? 'commits' : 'commit'
+            git_responses[tag] = "#{comparison.commits.size} undeployed #{word}. #{comparison.permalink_url}"
+            git_responses[tag] + ' :shipit:' if tag == 'production-release'
+          end
+        end
+
+        formatted_response = git_responses.map do |tag, comment|
+          "#{tag.upcase} : #{comment}"
+        end
+
+        formatted_response.join("\n")
+      end
+
+      def get_deployed_commit(repo_url)
+        deployed_status_data = fetch_deployed_status_data(repo_url)
+
+        # if the response object looks like a json object
+        if deployed_status_data.respond_to?(:keys)
+          commit_key = (JSON_COMMIT_ID_KEYS & deployed_status_data.keys).first
+          status_data = deployed_status_data.fetch(commit_key)
+          raise MissingStatusResponseData unless status_data
+
+          status_data
+        else
+          deployed_status_data
+        end
+      rescue KeyError
+        raise UnknownStatusResponseKey
+      end
+
+      def repo_type_and_url(repo_name)
+        url = IRREGULAR_ORG_URLS[repo_name]
+        if url
+          url
+        else
+          app_name = repo_name.split('/')[1]
+          "https://#{app_name}.zooniverse.org"
+        end
+      end
+
+      def production_release_tag(repo_name)
+        if branch_or_tag = DEPLOYED_BRANCH_REPOS[repo_name]
+          branch_or_tag
+        else
+          'production-release'
+        end
+      end
+
+      def fetch_deployed_status_data(repo_url)
+        # try the commit_id file first
+        repo_commit_id_url = "#{repo_url}/commit_id.txt"
+        repo_url_data = HTTParty.get(repo_commit_id_url)
+        if repo_url_data.code == 404
+          # let's try the root service url for some json data
+          repo_url_data = HTTParty.get(repo_url)
+        end
+        raise MissingStatusResponse if repo_url_data.code == 404
+
+        repo_url_data
+      rescue SocketError
+        raise UnknownServiceUrl
+      end
+    end
+  end
+end


### PR DESCRIPTION
add `lita status all` cmd to see the state of all known deployed repositories, E.g.
```
Lita > lita status all
talk-api
HEAD : is the currently deployed version.
PRODUCTION : is the currently deployed version.

panoptes
HEAD : 1 undeployed commit. https://github.com/zooniverse/panoptes/compare/zooniverse:a2f30d5...zooniverse:d66aaeb
PRODUCTION-RELEASE : is the currently deployed version.
```

This tracks the deployed repo names in a sorted redis set and reports each of these repo statuses in order from most frequently to least deployed. 

It will remove from the tracking set any repos that cannot be reported via GH (missing commit info, typos in name etc).