### PR TITLE
remove any surrounding whitespace in repo names

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -45,7 +45,9 @@ module Lita
 
       def tag_deploy(response)
         jenkins_job_name = JOBS.fetch('deploy')
-        repo_name = response.matches[0][1]
+        # ensure no leading/trailing whitespaces etc in the name
+        raw_repo_name = response.matches[0][1]
+        repo_name = raw_repo_name.strip
 
         # Track in redis sorted set which systems we are deploying
         # note: this might track some false positives


### PR DESCRIPTION
when deploying via slack, ensure we don't have any repo names like 'panoptes  '  as these don't align to any known repo and thus break the `status all` check.