### PR TITLE
add redsea deploy status

### DIFF
--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -21,7 +21,7 @@ module Lita
       JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze
       DEPLOYED_BRANCH_REPOS = {
         'zooniverse/talk-api' => 'production',
-        'zooniverse/zoo-stats-api-graphql' => 'master'
+        'zooniverse/zoo-stats-api-graphql' => 'master',
         'zooniverse/redsea' => 'main'
       }.freeze
       GH_PREVIEW_API_HEADERS = {

--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -22,6 +22,7 @@ module Lita
       DEPLOYED_BRANCH_REPOS = {
         'zooniverse/talk-api' => 'production',
         'zooniverse/zoo-stats-api-graphql' => 'master'
+        'zooniverse/redsea' => 'main'
       }.freeze
       GH_PREVIEW_API_HEADERS = {
         'Accept': 'application/vnd.github.groot-preview+json',


### PR DESCRIPTION
allow https://github.com/zooniverse/redsea to have it's deployment status reported. 

using new GH `main` branch and deployed from `main` to prod (no staging env yet)