### PR TITLE
Add a status URL for PFE

### DIFF
--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -13,6 +13,7 @@ module Lita
       class UnknonwnRepoCommit < StandardError; end
 
       IRREGULAR_ORG_URLS = {
+        'zooniverse/Panoptes-Front-End' => 'https://www.zooniverse.org/commit_id.txt',
         'zooniverse/pandora' => 'https://translations.zooniverse.org/commit_id.txt',
         'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
         'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',


### PR DESCRIPTION
Add www.zooniverse.org/commit_id.txt as the deploy status URL for PFE.