### PR TITLE
raise if we get a html response

### DIFF
--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -159,7 +159,9 @@ module Lita
           # let's try the root service url for some json data
           repo_url_data = HTTParty.get(repo_url)
         end
-        raise MissingStatusResponse if repo_url_data.code == 404
+        # 404's are obs bad and we can't really use html page responses, rather we prefer text / json
+        missing_status_response = repo_url_data.code == 404 || repo_url_data.content_type == 'text/html'
+        raise MissingStatusResponse if missing_status_response
 
         repo_url_data
       rescue SocketError


### PR DESCRIPTION
Fixes theia not reporting status.

The whole current paradigm is using text files or json responses, we don't want to have to parse a HTML page to get the status out of it (if it's in there)

instead of silently failing this will raise an relevant error instead.