### PR TITLE
Add front-end-monorepo status check

### DIFF
--- a/lib/github_status_reporter.rb
+++ b/lib/github_status_reporter.rb
@@ -13,6 +13,7 @@ module Lita
       class UnknonwnRepoCommit < StandardError; end
 
       IRREGULAR_ORG_URLS = {
+        'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/commit_id.txt',
         'zooniverse/pfe-lab' => 'https://lab.zooniverse.org/commit_id.txt',
         'zooniverse/Panoptes-Front-End' => 'https://www.zooniverse.org/commit_id.txt',
         'zooniverse/pandora' => 'https://translations.zooniverse.org/commit_id.txt',


### PR DESCRIPTION
Add fe-project.zooniverse.org/commit_id.txt as the status URL for the monorepo.