### PR TITLE
use production-release tag for talk api deploys

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -29,7 +29,6 @@ module Lita
 
       JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze
       DEPLOYED_BRANCH_REPOS = {
-        'zooniverse/talk-api' => 'production',
         'zooniverse/zoo-stats-api-graphql' => 'master'
       }.freeze
       GH_PREVIEW_API_HEADERS = {


### PR DESCRIPTION
Talk uses `production-release` tag to deploy via jenkins so we need to use this tag for lita to trigger deploys https://github.com/zooniverse/talk-api/blob/0799a540c2fd62f5e3b49341c6a4c70790e1b441/Jenkinsfile#L48