### PR TITLE
switch migrate jobs to use gh client for production-migrate tag

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -10,11 +10,6 @@ module Lita
   module Handlers
     class Deployment < Handler
 
-      JOBS = {
-        "deploy" => "Update production-release tag",
-        "migrate" => "Update production-migrate tag"
-      }
-
       DEPLOY_REPOS_SET_NAME = 'deploy-repos'
 
       config :jenkins_url, default: 'https://jenkins.zooniverse.org'
@@ -69,8 +64,9 @@ module Lita
       end
 
       def tag_migrate(response)
-        jenkins_job_name = JOBS.fetch('migrate')
-        build_jenkins_job(response, jenkins_job_name, { 'REPO' => repo_name_without_whitespace(response.matches[0][1]) })
+        repo_name = repo_name_without_whitespace(response.matches[0][1])
+        tag = config.github.update_production_migrate_tag(repo_name)
+        response.reply("Deployment tag '#{tag}' was successfully updated for #{repo_name}.")
       end
 
       def status(response)

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -97,18 +97,28 @@ module Lita
 
       def update_production_tag(repo_name)
         full_repo_name = orgify_repo_name(repo_name)
-        deploy_ref = 'tags/' + production_release_tag(full_repo_name)
+        deploy_ref = "tags/#{production_release_tag(full_repo_name)}"
+        update_tag(full_repo_name, deploy_ref)
+      end
 
+      def update_production_migrate_tag(repo_name)
+        full_repo_name = orgify_repo_name(repo_name)
+        deploy_ref = 'tags/production-migrate'
+        update_tag(full_repo_name, deploy_ref)
+      end
+
+      private
+
+      def update_tag(full_repo_name, deploy_ref)
         head_commit_id = octokit_client.refs(full_repo_name, primary_ref(full_repo_name)).object.sha
         commit_at_tag = octokit_client.refs(full_repo_name, deploy_ref).object.sha
 
         raise RefAlreadyDeployed, 'HEAD and tag commit SHAs match, ref already deployed' if head_commit_id == commit_at_tag
+
         update_ref_response = octokit_client.update_ref(full_repo_name, deploy_ref, head_commit_id)
         # Return name of updated tag
         update_ref_response[:ref].split('/')[2]
       end
-
-      private
 
       def status_error_response(msg, repo_url, error_prefix='Failed to fetch the deployed commit for this repo.')
         "#{error_prefix}\n#{msg} - #{repo_url}"


### PR DESCRIPTION
update a repo's `production-migrate` tag directly via the gh client vs running the job through jenkins's `Update production-migrate tag` job