### PR TITLE
Security reporter improvements

### DIFF
--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -14,8 +14,11 @@ module Lita
         get_issues = true
         last_repo_listed = nil
         repo_to_alert_count = {}
+        repo_to_alert_count.default = 0
         repo_to_high_alert_count = {}
+        repo_to_high_alert_count.default = 0
         repo_to_critical_alert_count = {}
+        repo_to_critical_alert_count.default = 0
         repo_to_reported_packages = {}
 
         while get_issues == true
@@ -76,13 +79,13 @@ module Lita
       end
 
       def add_alert_count(repo_to_alert_count, repo_name)
-        repo_alert_count = repo_to_alert_count[repo_name] || 0
+        repo_alert_count = repo_to_alert_count[repo_name]
         repo_to_alert_count[repo_name] = repo_alert_count + 1
       end
 
       def format_alerts(repo_to_alert_count, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
         repo_to_alert_count.map do |repo, count|
-          "[#{repo}](https://github.com/zooniverse/#{repo}/security/dependabot) -- #{count} (#{repo_to_high_alert_count[repo] || 0} HIGH; #{repo_to_critical_alert_count[repo] || 0} CRITICAL) #{repo_to_reported_packages[repo].length} flagged packages"
+          "[#{repo}](https://github.com/zooniverse/#{repo}/security/dependabot) -- #{count} (#{repo_to_high_alert_count[repo]} HIGH; #{repo_to_critical_alert_count[repo]} CRITICAL) #{repo_to_reported_packages[repo].length} flagged packages"
         end.join("\n")
       end
 

--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -36,7 +36,7 @@ module Lita
 
             next if @repos_to_skip.include? repo_name.downcase
 
-            filter_fixed_or_dismissed_alerts node_alerts, repo_to_alert_count, repo_name,
+            categorize_alerts_by_severity node_alerts, repo_to_alert_count, repo_name,
                                              repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages
           end
           repo_count = edges.length
@@ -55,7 +55,7 @@ module Lita
         repo_to_alert_count.reduce(0) { |sum, (_, count)| sum + count }
       end
 
-      def filter_fixed_or_dismissed_alerts(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
+      def categorize_alerts_by_severity(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
         node_alerts.each do |alert|
           vulnerability = alert['securityVulnerability']
           add_alert_count(repo_to_alert_count, repo_name)

--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -16,7 +16,7 @@ module Lita
         repo_to_alert_count = {}
         repo_to_high_alert_count = {}
         repo_to_critical_alert_count = {}
-        repo_to_package_count = {}
+        repo_to_reported_packages = {}
 
         while get_issues == true
           res = config.github.get_dependabot_issues(last_repo_listed)
@@ -37,16 +37,16 @@ module Lita
             next if @repos_to_skip.include? repo_name.downcase
 
             filter_fixed_or_dismissed_alerts node_alerts, repo_to_alert_count, repo_name,
-                                             repo_to_high_alert_count, repo_to_critical_alert_count
+                                             repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages
           end
           repo_count = edges.length
           last_repo_listed = edges[repo_count - 1]['cursor']
           get_issues = false if repo_count < 100
         end
 
-        summary = "#{total_alert_count(repo_to_alert_count)} Alerts Total (#{total_alert_count(repo_to_high_alert_count)} HIGH; #{total_alert_count(repo_to_critical_alert_count)} CRITICAL):"
-        response.reply("#{summary}: \n #{format_alerts(repo_to_alert_count, repo_to_high_alert_count,
-                                                       repo_to_critical_alert_count)}")
+        summary = "#{total_alert_count(repo_to_alert_count)} Alerts Total (#{total_alert_count(repo_to_high_alert_count)} HIGH; #{total_alert_count(repo_to_critical_alert_count)} CRITICAL)"
+        response.reply("#{summary}: \n#{format_alerts(repo_to_alert_count, repo_to_high_alert_count,
+                                                      repo_to_critical_alert_count, repo_to_reported_packages)}")
       end
 
       private
@@ -55,7 +55,7 @@ module Lita
         repo_to_alert_count.reduce(0) { |sum, (_, count)| sum + count }
       end
 
-      def filter_fixed_or_dismissed_alerts(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count)
+      def filter_fixed_or_dismissed_alerts(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
         node_alerts.each do |alert|
           vulnerability = alert['securityVulnerability']
           add_alert_count(repo_to_alert_count, repo_name)
@@ -63,7 +63,16 @@ module Lita
           severity = vulnerability['severity'].downcase
           add_alert_count(repo_to_high_alert_count, repo_name) if severity == 'high'
           add_alert_count(repo_to_critical_alert_count, repo_name) if severity == 'critical'
+
+          package_name = vulnerability['package']['name'].downcase
+          add_unique_reported_packages(repo_to_reported_packages, repo_name, package_name)
         end
+      end
+
+      def add_unique_reported_packages(repo_to_reported_packages, repo_name, package_name)
+        packages = repo_to_reported_packages[repo_name] || []
+        packages << package_name unless packages.include? package_name
+        repo_to_reported_packages[repo_name] = packages
       end
 
       def add_alert_count(repo_to_alert_count, repo_name)
@@ -71,9 +80,9 @@ module Lita
         repo_to_alert_count[repo_name] = repo_alert_count + 1
       end
 
-      def format_alerts(repo_to_alert_count, repo_to_high_alert_count, repo_to_critical_alert_count)
+      def format_alerts(repo_to_alert_count, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
         repo_to_alert_count.map do |repo, count|
-          "[#{repo}](https://github.com/zooniverse/#{repo}/security/dependabot) -- #{count} (#{repo_to_high_alert_count[repo] || 0} HIGH; #{repo_to_critical_alert_count[repo] || 0} CRITICAL)"
+          "[#{repo}](https://github.com/zooniverse/#{repo}/security/dependabot) -- #{count} (#{repo_to_high_alert_count[repo] || 0} HIGH; #{repo_to_critical_alert_count[repo] || 0} CRITICAL) #{repo_to_reported_packages[repo].length} flagged packages"
         end.join("\n")
       end
 

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -132,7 +132,6 @@ module Lita
               }
               nodes {
                 name
-                resourcePath
                 vulnerabilityAlerts(first: 100, states: OPEN) {
                   nodes {
                     securityVulnerability {
@@ -165,7 +164,6 @@ module Lita
               }
               nodes {
                 name
-                resourcePath
                 vulnerabilityAlerts(first: 100, states: OPEN) {
                   nodes {
                     securityVulnerability {

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -132,7 +132,8 @@ module Lita
               }
               nodes {
                 name
-                vulnerabilityAlerts(first: 100) {
+                resourcePath
+                vulnerabilityAlerts(first: 100, states: OPEN) {
                   nodes {
                     securityVulnerability {
                       package {
@@ -164,7 +165,8 @@ module Lita
               }
               nodes {
                 name
-                vulnerabilityAlerts(first: 100) {
+                resourcePath
+                vulnerabilityAlerts(first: 100, states: OPEN) {
                   nodes {
                     securityVulnerability {
                       package {


### PR DESCRIPTION
**CURRENT CHANGES**
- Update Query to have graphql filter for correct state which is OPEN (this will give us a true number of issues as seen on repo's security tab and saves us the need to filter)
- removing cellect from repos to skip since it is still in use
-  display along with totals amount of high and critical issues and how many unique packages cause these alerts.
- update format of reporter to display `[repo](link to repo) -- alerts`

**TODO (for another PR/hackday)**
- report by repo (I think personally it is better to use specific graphql query done by repo i.e.
- REFACTOR  https://github.com/zooniverse/lita/pull/120#discussion_r825932135 I do like Cam's review on refactoring, adding this as debt for me to do later 
- Sentry error reporting (Will open in another PR)
``` 
def dependabot_query_for_specific_repo(repo_name)
        <<-GRAPHQL
          {
            organization(login: "zooniverse") {
              repository(name: "#{repo_name}") {
                vulnerabilityAlerts(first:100, states: OPEN) {
                  nodes {
                    securityVulnerability {
                      package {
                        name
                      }
                      severity
                    }
                  }
                }
              }
            }
          }
        GRAPHQL
      end
``` 

instead of using the `repo_to_alert` maps generated from the current security_reporter (since it does unnecessary extra queries to gh graphql api. Will save this project (reporting by specific repo) for another day. I'm also unsure how useful doing a security reporter by repo is since one could technically go on that specific repo's gh security tab.

- update query to grab all alerts if repo has 100+ vulnerability alerts. 