### PR TITLE
update to parse to mkdwn

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -31,6 +31,7 @@ Lita.configure do |config|
 
     ## Example: Set options for the chosen adapter.
     config.adapters.slack.token = ENV["SLACK_TOKEN"]
+    config.adapters.slack.parse = "mrkdwn"
   end
 
   config.http.port = ENV["PORT"] || 80


### PR DESCRIPTION
updating slack config for lita to display mrkdown. following docs:  https://github.com/litaio/lita-slack. unsure if this will work since the options for .parse wasn't really clear, but followed https://api.slack.com/reference/surfaces/formatting#parsing_modes as a guide. 
