### PR TITLE
use the authed client to avoid rate limits

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -204,7 +204,7 @@ module Lita
       def get_app_status(repo_name, deployed_version, prod_tag)
         git_responses = {}
         ['HEAD', prod_tag].each do |tag|
-          comparison = Octokit.compare(repo_name, deployed_version.strip, tag)
+          comparison = octokit_client.compare(repo_name, deployed_version.strip, tag)
           if comparison.commits.empty?
             git_responses[tag] = 'is the currently deployed version.'
           else


### PR DESCRIPTION
switch from the non-authed `lita status $repo` compare request to the authed client one. This will avoid rate limits such as 

> GET https://api.github.com/repos/zooniverse/interventions-gateway/compare/6efdd0b29756d400d40cf0016f733c269dde3f52...HEAD: 403 - API rate limit exceeded for 40.88.52.209. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) // See: https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting
Full backtrace:
/usr/local/bundle/gems/octokit-4.19.0/lib/octokit/response/raise_error.rb:16:in `on_complete'