### PR TITLE
Update HEAD for `zooniverse/pandora`

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -29,6 +29,7 @@ module Lita
 
       # Repos that do not use heads/master as their primary ref
       PRIMARY_REF_BY_REPO = {
+        'zooniverse/pandora' => 'heads/main'
       }.freeze
 
       JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze


### PR DESCRIPTION
Pandora's main branch is now `main`.