### PR TITLE
case insensitive repo url name matching

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -17,10 +17,11 @@ module Lita
 
       class RefAlreadyDeployed < StandardError; end
 
-      IRREGULAR_ORG_URLS = {
+      # ensure these are all downcased for easy matching
+      IRREGULAR_DOWNCASED_ORG_URLS = {
         'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects/commit_id.txt',
         'zooniverse/pfe-lab' => 'https://lab.zooniverse.org/commit_id.txt',
-        'zooniverse/Panoptes-Front-End' => 'https://www.zooniverse.org/commit_id.txt',
+        'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org/commit_id.txt',
         'zooniverse/pandora' => 'https://translations.zooniverse.org/commit_id.txt',
         'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
         'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',
@@ -240,7 +241,7 @@ module Lita
       end
 
       def repo_type_and_url(repo_name)
-        url = IRREGULAR_ORG_URLS[repo_name]
+        url = IRREGULAR_DOWNCASED_ORG_URLS[repo_name.downcase]
         if url
           url
         else


### PR DESCRIPTION
This PR allows the status cmd to ignore case when matching repo names and makes life easier for the folks using chat ops. We can do this as github repo names are case insensitive so shouldn't clash on any chat ops cmds.

Before this PR something like
```
Lita > lita status panoptes-front-end
Failed to fetch the deployed commit for this repo.
No service is running on the url - https://panoptes-front-end.zooniverse.org
```
After this PR change we now get
```
Lita > lita status panoptes-front-end
HEAD : is the currently deployed version.
PRODUCTION-RELEASE : is the currently deployed version.
```