### PR TITLE
Add Serengeti repo to the security alerts ignore list

### DIFF
--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -35,7 +35,7 @@ module Lita
             repo_name = node['name']
 
             @repos_to_skip ||= %w[next-cookie-auth-panoptes science-gossip-data seven-ten
-                                  Seven-Ten-Client Social Sellers Exercise CSA-Home].map(&:downcase)
+                                  Seven-Ten-Client Social Sellers Exercise CSA-Home Serengeti].map(&:downcase)
 
             next if @repos_to_skip.include? repo_name.downcase
 


### PR DESCRIPTION
[Serengeti](https://github.com/zooniverse/Serengeti) custom frontend is not actually in use and its Security tab doesn't show dependabot alerts, so let's ignore it in lita's `security report` command.