### PR TITLE
Apply ingresses via chatops

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -71,8 +71,7 @@ module Lita
       end
 
       def apply_ingresses(response)
-        deploy_ref = 'tags/production-ingresses'
-        update_tag('zooniverse/static', deploy_ref)
+        config.github.update_production_ingresses_tag
         response.reply("Ingress tag was successfully updated for static.")
       end
 

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -120,6 +120,14 @@ module Lita
         octokit_client.post '/graphql', { query: query }.to_json
       end
 
+      def run_workflow(repo_name, workflow, branch, inputs={})
+        params = {
+          ref: 'refs/heads/#{branch}',
+          inputs: inputs
+        }
+        octokit_client.post("/repos/zooniverse/#{repo_name}/actions/workflows/#{workflow}/dispatches", params)
+      end
+
       private
 
       def query_without_after

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -114,6 +114,10 @@ module Lita
         update_tag(full_repo_name, deploy_ref)
       end
 
+      def update_production_ingresses_tag
+        update_tag('zooniverse/static', 'tags/production-ingresses')
+      end
+
       def get_dependabot_issues(last_repo_listed)
         query = last_repo_listed ? query_with_after(last_repo_listed) : query_without_after
 

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -124,14 +124,6 @@ module Lita
         octokit_client.post '/graphql', { query: query }.to_json
       end
 
-      def run_workflow(repo_name, workflow, branch, inputs={})
-        params = {
-          ref: 'refs/heads/#{branch}',
-          inputs: inputs
-        }
-        octokit_client.post("/repos/zooniverse/#{repo_name}/actions/workflows/#{workflow}/dispatches", params)
-      end
-
       private
 
       def query_without_after


### PR DESCRIPTION
This will allow us to run Github Actions via Lita in Slack. Adds `lita action REPO FILENAME BRANCH` and some shortcuts for `lita static nginx` and `lita static ingress` (see https://github.com/zooniverse/static/pull/277). I've got to do some more testing because it doesn't seem like it's respecting the branch as an input parameter, all my tests have run on master so far. Need to dig into the API endpoint (https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) and ensure that I'm sending it what it wants.

Feedback welcome.