### PR TITLE
Add jobs.zooniverse.org to list of irregular repos

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -26,7 +26,8 @@ module Lita
         'zooniverse/scribes-of-the-cairo-geniza' => 'https://www.scribesofthecairogeniza.org/commit_id.txt',
         'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
         'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',
-        'zooniverse/zoo-event-stats' => 'https://stats.zooniverse.org/'
+        'zooniverse/zoo-event-stats' => 'https://stats.zooniverse.org/',
+        'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org/commit_id.txt'
       }.freeze
 
       # Repos that do not use heads/master as their primary ref


### PR DESCRIPTION
Having the full URL in the repo name was confusing Lita when she was looking for the status of the jobs.zooniverse.org repo.