### PR TITLE
Security new this week

### DIFF
--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -11,6 +11,7 @@ module Lita
                                                                  help: { 'status dependabot' => 'displays dependabot security alerts' })
 
       def get_dependabot_issues(response)
+        filter = filter_without_whitespace(response.matches[0][1])
         get_issues = true
         last_repo_listed = nil
         repo_to_alert_count = {}

--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -54,6 +54,10 @@ module Lita
 
       private
 
+      def filter_without_whitespace(filter)
+        filter.strip
+      end
+
       def total_alert_count(repo_to_alert_count)
         repo_to_alert_count.reduce(0) { |sum, (_, count)| sum + count }
       end

--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -40,7 +40,7 @@ module Lita
             next if @repos_to_skip.include? repo_name.downcase
 
             categorize_alerts_by_severity node_alerts, repo_to_alert_count, repo_name,
-                                             repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages
+                                             repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages, filter
           end
           repo_count = edges.length
           last_repo_listed = edges[repo_count - 1]['cursor']
@@ -62,8 +62,10 @@ module Lita
         repo_to_alert_count.reduce(0) { |sum, (_, count)| sum + count }
       end
 
-      def categorize_alerts_by_severity(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
+      def categorize_alerts_by_severity(node_alerts, repo_to_alert_count, repo_name, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages, filter)
         node_alerts.each do |alert|
+          next if (filter.downcase.include? 'this week') && (Date.parse(alert['createdAt']) <= (Date.today - 7))
+
           vulnerability = alert['securityVulnerability']
           add_alert_count(repo_to_alert_count, repo_name)
 

--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -89,7 +89,7 @@ module Lita
 
       def format_alerts(repo_to_alert_count, repo_to_high_alert_count, repo_to_critical_alert_count, repo_to_reported_packages)
         repo_to_alert_count.map do |repo, count|
-          "<https://github.com/zooniverse/#{repo}/security/dependabot | #{repo}> -- #{count} (#{repo_to_high_alert_count[repo]} HIGH; #{repo_to_critical_alert_count[repo]} CRITICAL) #{repo_to_reported_packages[repo].length} flagged packages"
+          "<https://github.com/zooniverse/#{repo}/security/dependabot|#{repo}> -- #{count} (#{repo_to_high_alert_count[repo]} HIGH; #{repo_to_critical_alert_count[repo]} CRITICAL) #{repo_to_reported_packages[repo].length} flagged packages"
         end.join("\n")
       end
 

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -143,6 +143,7 @@ module Lita
                     }
                     dismissedAt
                     fixedAt
+                    createdAt
                   }
                 }
               }
@@ -175,6 +176,7 @@ module Lita
                     }
                     dismissedAt
                     fixedAt
+                    createdAt
                   }
                 }
               }


### PR DESCRIPTION
filters out for new alerts of the week (returns only the alerts created 7 days before the `lita security report new this week` command gets called.) 