### PR TITLE
Add sugar repo to irregular URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,5 @@ gem 'dotenv'
 group :development, :test do
   gem 'pry'
   gem 'rspec'
+  gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     a_vs_an (0.1.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     coderay (1.1.0)
     concurrent-ruby (1.1.7)
     diff-lcs (1.3)
@@ -89,6 +90,9 @@ GEM
     octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -98,12 +102,15 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rb-readline (0.5.5)
     read_it (0.0.2)
       faraday (>= 0.8.7)
     redis (4.2.2)
     redis-namespace (1.8.0)
       redis (>= 3.0.4)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -117,6 +124,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (1.30.1)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.2)
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
@@ -161,6 +180,7 @@ DEPENDENCIES
   octokit
   pry
   rspec
+  rubocop
 
 BUNDLED WITH
    2.1.4

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -19,15 +19,16 @@ module Lita
 
       # ensure these are all downcased for easy matching
       IRREGULAR_DOWNCASED_ORG_URLS = {
-        'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects/commit_id.txt',
-        'zooniverse/pfe-lab' => 'https://lab.zooniverse.org/commit_id.txt',
-        'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org/commit_id.txt',
-        'zooniverse/pandora' => 'https://translations.zooniverse.org/commit_id.txt',
-        'zooniverse/scribes-of-the-cairo-geniza' => 'https://www.scribesofthecairogeniza.org/commit_id.txt',
-        'zooniverse/talk-api' => 'https://talk.zooniverse.org/commit_id.txt',
-        'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org',
+        'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects',
+        'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
+        'zooniverse/pandora' => 'https://translations.zooniverse.org',
+        'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org',
+        'zooniverse/pfe-lab' => 'https://lab.zooniverse.org',
+        'zooniverse/scribes-of-the-cairo-geniza' => 'https://www.scribesofthecairogeniza.org',
+        'zooniverse/sugar' => 'https://notifications.zooniverse.org',
+        'zooniverse/talk-api' => 'https://talk.zooniverse.org',
         'zooniverse/zoo-event-stats' => 'https://stats.zooniverse.org/',
-        'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org/commit_id.txt'
+        'zooniverse/zoo-stats-api-graphql' => 'https://graphql-stats.zooniverse.org'
       }.freeze
 
       # Repos that do not use heads/master as their primary ref


### PR DESCRIPTION
this PR adds the sugar repo for chat ops deploys. It also fixes the existing URLs to ensure they can use the root page json fallback options as well, i.e. avoid adding the `commit_id.txt` suffix as it's added dynamically when attempting to fetch status via https://github.com/zooniverse/lita/blob/ccc431ea84391fdfd43ed13fe4403b11c36dd4a9/lib/zooniverse_github.rb#L271