### PR TITLE
add a small wait before requesting the latest action workflow run

### DIFF
--- a/handlers/deployment.rb
+++ b/handlers/deployment.rb
@@ -46,6 +46,10 @@ module Lita
       def rebuild_subject_set_search_api(response)
         repo_name = config.github.orgify_repo_name('subject-set-search-api')
         config.github.run_workflow(repo_name, 'deploy.yml', 'main')
+        # pause for a period of seconds while the GH API syncs
+        # to ensure we pickup the most recently submited job run
+        gh_api_wait_time = rand(2..4)
+        sleep(gh_api_wait_time)
         workflow_run = config.github.get_latest_workflow_run(repo_name, 'deploy.yml', 'main')
         response.reply('Subject-Set-Search-API Rebuild initiated:')
         response.reply("Details at #{workflow_run[:html_url]}")


### PR DESCRIPTION
Follow up to #139 

Calling the get latest workflow run details straight after a workflow run create request may not return the recently submitted action workflow run but may return a previous one. Thus we can add a small wait to allow the GH API to sync the data correctly before requesting this information