### PR TITLE
Add anti-slavery-manuscripts to irregular urls list

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -19,6 +19,7 @@ module Lita
 
       # ensure these are all downcased for easy matching
       IRREGULAR_DOWNCASED_ORG_URLS = {
+        'zooniverse/anti-slavery-manuscripts' => 'https://www.antislaverymanuscripts.org',
         'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects',
         'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
         'zooniverse/pandora' => 'https://translations.zooniverse.org',


### PR DESCRIPTION
Updates lita's list of irregular urls to include Anti-Slavery Manuscripts urls, so in Slack #deploys `lita status anti-slavery-manuscripts` works, similar to Scribes of the Cairo Geniza.