### PR TITLE
Add notes-from-nature-field-book to irregular urls list

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -22,6 +22,7 @@ module Lita
         'zooniverse/anti-slavery-manuscripts' => 'https://www.antislaverymanuscripts.org',
         'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects',
         'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
+        'zooniverse/notes-from-nature-field-book' => 'https://field-book.notesfromnature.org/',
         'zooniverse/pandora' => 'https://translations.zooniverse.org',
         'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org',
         'zooniverse/pfe-lab' => 'https://lab.zooniverse.org',


### PR DESCRIPTION
Updates lita's list of irregular urls to include Notes from Nature Field Book url, so in Slack `lita status notes-from-nature-field-book` works as expected.