### PR TITLE
Delete slash from notes-from-nature-field-book url

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -22,7 +22,7 @@ module Lita
         'zooniverse/anti-slavery-manuscripts' => 'https://www.antislaverymanuscripts.org',
         'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects',
         'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
-        'zooniverse/notes-from-nature-field-book' => 'https://field-book.notesfromnature.org/',
+        'zooniverse/notes-from-nature-field-book' => 'https://field-book.notesfromnature.org',
         'zooniverse/pandora' => 'https://translations.zooniverse.org',
         'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org',
         'zooniverse/pfe-lab' => 'https://lab.zooniverse.org',


### PR DESCRIPTION
Deletes forward slash from notes-from-nature-field-book url listed in `IRREGULAR_DOWNCASED_ORG_URLS`.