### PR TITLE
lita-slack referenced to cleaner branch and handle messagehandler errors te…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "lita"
 
 group :production do
-  gem 'lita-slack', git: 'https://github.com/yuenmichelle1/lita-slack.git', branch: 'test-new-connection', ref: '7b64843'
+  gem 'lita-slack', git: 'https://github.com/yuenmichelle1/lita-slack.git', branch: 'connection-using-rtm-connect', ref: 'e3e49f5'
 end
 
 gem "lita-karma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/yuenmichelle1/lita-slack.git
-  revision: 7b648432639e752fcb8d27929707a325238cd509
-  ref: 7b64843
-  branch: test-new-connection
+  revision: e3e49f50cea2ea42c1a46679d9923f97481731b5
+  ref: e3e49f5
+  branch: connection-using-rtm-connect
   specs:
     lita-slack (1.8.0)
       eventmachine


### PR DESCRIPTION
Temporary fix. Pointing lita-slack gem to cleaner branch that handles MessageHandler errors appropriately