### PR TITLE
Lita code scanning for highest priority repos

### DIFF
--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -8,6 +8,14 @@ module Lita
       config :github, default: Zooniverse::Github.new
 
       route(/^(security report)\s*(.*)/, :get_dependabot_issues, command: true, help: { 'security report(s) (this week)' => 'displays dependabot security alerts' })
+      route(/^(code scan report)\s*(.*)/, :get_code_scanned_issues, command: true, help: {'code scan report(s)' => 'displays dependabot code scanning alerts' })
+
+      def get_code_scanned_issues(response)
+        res = config.github.code_scanned_issues
+        puts "MDY114"
+        puts res
+        response.reply("HELLOOOO code scan result #{res}")
+      end
 
       def get_dependabot_issues(response)
         filter = filter_without_whitespace(response.matches[0][1])

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -130,11 +130,8 @@ module Lita
         octokit_client.post '/graphql', { query: query }.to_json
       end
 
-      def code_scanned_issues
-        octokit_client.get '/orgs/zooniverse/code-scanning/alerts'
-      rescue Octokit::Error => error
-        puts "MDY114 ERROR"
-        puts error
+      def code_scanned_issues_per_repo(repo)
+        octokit_client.get("/repos/zooniverse/#{repo}/code-scanning/alerts", { state: 'open' })
       end
 
       def run_workflow(repo_name, workflow_file_name, ref, options = {})

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -130,6 +130,13 @@ module Lita
         octokit_client.post '/graphql', { query: query }.to_json
       end
 
+      def code_scanned_issues
+        octokit_client.get '/orgs/zooniverse/code-scanning/alerts'
+      rescue Octokit::Error => error
+        puts "MDY114 ERROR"
+        puts error
+      end
+
       def run_workflow(repo_name, workflow_file_name, ref, options = {})
         octokit_client.workflow_dispatch(repo_name, workflow_file_name, ref, options)
       end


### PR DESCRIPTION
Updating lita security reporter to view code-ql scanned issues.
See:
https://docs.github.com/en/rest/code-scanning 

We want to do this on an org level, however GH only allows org level code-scanning rest api endpoint to be available to enterprises with Advanced Security feature setup. As a workaround, we will be scanning our highest priority repos gauged from ZTM by PIs. 

TODO:
there is some repeated code now with the code scan report and dependabot report issues, will need a bit of a refactor 