### PR TITLE
Update PFE and FEM's commit check URLs

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -21,7 +21,7 @@ module Lita
       IRREGULAR_DOWNCASED_ORG_URLS = {
         'zooniverse/aggregation-for-caesar' => 'https://aggregation-caesar.zooniverse.org/',
         'zooniverse/anti-slavery-manuscripts' => 'https://www.antislaverymanuscripts.org',
-        'zooniverse/front-end-monorepo' => 'https://fe-project.zooniverse.org/projects',
+        'zooniverse/front-end-monorepo' => 'https://fe-root.zooniverse.org',
         'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
         'zooniverse/notes-from-nature-field-book' => 'https://field-book.notesfromnature.org',
         'zooniverse/pandora' => 'https://translations.zooniverse.org',

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -25,7 +25,7 @@ module Lita
         'zooniverse/jobs.zooniverse.org' => 'https://jobs.zooniverse.org',
         'zooniverse/notes-from-nature-field-book' => 'https://field-book.notesfromnature.org',
         'zooniverse/pandora' => 'https://translations.zooniverse.org',
-        'zooniverse/panoptes-front-end' => 'https://www.zooniverse.org',
+        'zooniverse/panoptes-front-end' => 'https://static.zooniverse.org/www.zooniverse.org',
         'zooniverse/pfe-lab' => 'https://lab.zooniverse.org',
         'zooniverse/scribes-of-the-cairo-geniza' => 'https://www.scribesofthecairogeniza.org',
         'zooniverse/sugar' => 'https://notifications.zooniverse.org',


### PR DESCRIPTION
Post-switcheroo, www.zooniverse.org/commit_id.txt is served from the fe-root app, not PFE. This confuses lita, who uses that URL for PFE checks. This updates that check to use the `static.zooniverse.org/www.zooniverse.org` path which still gets updated on PFE deploys but isn't served by www. 

Also updated FEM's check to check the fe-root app instead of projects. Using the app directly instead of www to avoid the CDN, just in case.