### PR TITLE
Remove aggregation from nonstandard tag list

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -43,8 +43,7 @@ module Lita
 
       JSON_COMMIT_ID_KEYS = %w[revision commit_id].freeze
       DEPLOYED_BRANCH_REPOS = {
-        'zooniverse/zoo-stats-api-graphql' => 'master',
-        'zooniverse/aggregation-for-caesar' => 'master'
+        'zooniverse/zoo-stats-api-graphql' => 'master'
       }.freeze
       GH_PREVIEW_API_HEADERS = {
         'Accept': 'application/vnd.github.groot-preview+json',


### PR DESCRIPTION
Aggregation was migrated to the standard deployment scheme, utilizing the `production-release` tag and dual actions and templates. This removes the repo from the list of non-standard "deployed from master" apps.