### PR TITLE
Add repos to skip list in security reporter

### DIFF
--- a/handlers/security_reporter.rb
+++ b/handlers/security_reporter.rb
@@ -89,7 +89,7 @@ module Lita
 
             repo_name = node['name']
 
-            @repos_to_skip ||= %w[science-gossip-data Sellers Exercise CSA-Home].map(&:downcase)
+            @repos_to_skip ||= %w[astrovector CSA-Home data.galaxyzoo.org Data-digging gz_nodes_flask kSWAP iiif-annotations mapping-viz-functions mapping-viz-tools PRN-maps mobile-provisioning-profiles retirement science-gossip-data Sellers swap uscientist volumetric-viewer zoo-grommet zootools-sheets].map(&:downcase)
 
             next if @repos_to_skip.include? repo_name.downcase
 


### PR DESCRIPTION
Adding more repos to the list of skipped security alerts. These repos are not archived (yet), but the frontend team does not dedicate time to managing security alerts for them.

Note - I saw that Exercise is archived so I don't think it needs to be included, but please feel free to edit this PR as needed!