### PR TITLE
Make main-master switch for FEM

### DIFF
--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -35,6 +35,7 @@ module Lita
 
       # Repos that do not use heads/master as their primary ref
       PRIMARY_REF_BY_REPO = {
+        'zooniverse/front-end-monorepo' => 'heads/main',
         'zooniverse/panoptes-front-end' => 'heads/main',
         'zooniverse/pandora' => 'heads/main',
         'zooniverse/kade' => 'heads/main',


### PR DESCRIPTION
FEM changed primary branch from master to main on 7 Nov 2025; here we make a switch to accommodate that change.