### PR TITLE
Add 'status static' functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,9 @@ gem "lita-cron"
 gem "httparty"
 gem "octokit"
 gem "a_vs_an"
-gem 'faye-websocket', git: 'https://github.com/faye/faye-websocket-ruby.git', branch: 'main'
-gem 'http_router', git: 'https://github.com/joshbuddy/http_router.git', branch: 'master'
+gem 'faye-websocket'
+gem 'http_router'
+gem 'nio4r', '~> 2.7'
 
 gem 'dotenv'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,4 @@
 GIT
-  remote: https://github.com/faye/faye-websocket-ruby.git
-  revision: d9428fae72240bfa8b98627a0414524814b92f22
-  branch: main
-  specs:
-    faye-websocket (0.11.1)
-      eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.5.1)
-
-GIT
-  remote: https://github.com/joshbuddy/http_router.git
-  revision: defc049bf6fa7fb80c38f605a492a6185fae90b6
-  branch: master
-  specs:
-    http_router (0.11.2)
-      rack (>= 1.0.0)
-      url_mount (~> 0.2.1)
-
-GIT
   remote: https://github.com/zooniverse/lita-slack.git
   revision: f686df4dafc50cfcfdd37a3e73e4c43dd3deb644
   ref: f686df4
@@ -36,6 +18,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    base64 (0.3.0)
     coderay (1.1.0)
     concurrent-ruby (1.1.7)
     diff-lcs (1.3)
@@ -45,6 +28,12 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
+    faye-websocket (0.12.0)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.8.0)
+    http_router (0.11.2)
+      rack (>= 1.0.0)
+      url_mount (~> 0.2.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -91,7 +80,7 @@ GEM
     mini_portile2 (2.8.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    nio4r (2.5.8)
+    nio4r (2.7.5)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -157,7 +146,8 @@ GEM
     unicode-display_width (1.4.0)
     url_mount (0.2.1)
       rack
-    websocket-driver (0.7.5)
+    websocket-driver (0.8.0)
+      base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
@@ -167,8 +157,8 @@ PLATFORMS
 DEPENDENCIES
   a_vs_an
   dotenv
-  faye-websocket!
-  http_router!
+  faye-websocket
+  http_router
   httparty
   lita
   lita-applause
@@ -182,6 +172,7 @@ DEPENDENCIES
   lita-lunch
   lita-pugbomb
   lita-slack!
+  nio4r (~> 2.7)
   octokit
   pry
   rspec

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -256,11 +256,7 @@ module Lita
       end
 
       def get_deployed_commit(repo_url)
-        deployed_status_data = if repo_url.include?('static.zooniverse.org')
-          fetch_static_deployment
-        else
-          fetch_deployed_status_data(repo_url)
-        end
+        deployed_status_data = fetch_deployed_status_data(repo_url)
 
         # if the response object looks like a json object
         if deployed_status_data.respond_to?(:keys)
@@ -295,31 +291,28 @@ module Lita
       end
 
       def fetch_deployed_status_data(repo_url)
-        # try the commit_id file first
-        repo_commit_id_url = "#{repo_url}/commit_id.txt"
-        repo_url_data = HTTParty.get(repo_commit_id_url)
-        if repo_url_data.code == 404
-          # let's try the root service url for some json data
-          repo_url_data = HTTParty.get(repo_url)
+        # Static repo needs special handling
+        repo_url_data = if repo_url == 'https://static.zooniverse.org'
+          # Any path that is processed by the static proxy but NOT behind FD/CDN
+          static_repo_url = 'https://status.zooniverse.org/'
+          custom_headers = {
+            # specific host header responds with deployed proxy version
+            'Host' => 'proxy-version',
+          }
+          HTTParty.get(static_repo_url, headers: custom_headers)
+        else
+          # try the commit_id file first
+          repo_commit_id_url = "#{repo_url}/commit_id.txt"
+          response = HTTParty.get(repo_commit_id_url)
+          if response.code == 404
+            # let's try the root service url for some json data
+            HTTParty.get(repo_url)
+          else
+            response
+          end
         end
-        # 404's are obs bad and we can't really use html page responses, rather we prefer text / json
-        missing_status_response = repo_url_data.code == 404 || repo_url_data.content_type == 'text/html'
-        raise MissingStatusResponse if missing_status_response
 
-        repo_url_data
-      rescue SocketError
-        raise UnknownServiceUrl
-      end
-
-      def fetch_static_deployment
-        # Any path that is processed by the static proxy but not behind CDN
-        static_repo_url = 'https://status.zooniverse.org/'
-        custom_headers = {
-          # specific host header responds with deployed proxy version
-          'Host' => 'proxy-version',
-        }
-        repo_url_data = HTTParty.get(static_repo_url, headers: custom_headers)
-
+        # Can't parse status from a 404 or HTML response
         missing_status_response = repo_url_data.code == 404 || repo_url_data.content_type == 'text/html'
         raise MissingStatusResponse if missing_status_response
 

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -294,7 +294,7 @@ module Lita
         # Static repo needs special handling
         repo_url_data = if repo_url == 'https://static.zooniverse.org'
           # Any path that is processed by the static proxy but NOT behind FD/CDN
-          static_repo_url = 'https://status.zooniverse.org/'
+          static_repo_url = 'https://panoptes.zooniverse.org'
           custom_headers = {
             # specific host header responds with deployed proxy version
             'Host' => 'proxy-version',

--- a/lib/zooniverse_github.rb
+++ b/lib/zooniverse_github.rb
@@ -256,7 +256,11 @@ module Lita
       end
 
       def get_deployed_commit(repo_url)
-        deployed_status_data = fetch_deployed_status_data(repo_url)
+        deployed_status_data = if repo_url.include?('static.zooniverse.org')
+          fetch_static_deployment
+        else
+          fetch_deployed_status_data(repo_url)
+        end
 
         # if the response object looks like a json object
         if deployed_status_data.respond_to?(:keys)
@@ -299,6 +303,23 @@ module Lita
           repo_url_data = HTTParty.get(repo_url)
         end
         # 404's are obs bad and we can't really use html page responses, rather we prefer text / json
+        missing_status_response = repo_url_data.code == 404 || repo_url_data.content_type == 'text/html'
+        raise MissingStatusResponse if missing_status_response
+
+        repo_url_data
+      rescue SocketError
+        raise UnknownServiceUrl
+      end
+
+      def fetch_static_deployment
+        # Any path that is processed by the static proxy but not behind CDN
+        static_repo_url = 'https://status.zooniverse.org/'
+        custom_headers = {
+          # specific host header responds with deployed proxy version
+          'Host' => 'proxy-version',
+        }
+        repo_url_data = HTTParty.get(static_repo_url, headers: custom_headers)
+
         missing_status_response = repo_url_data.code == 404 || repo_url_data.content_type == 'text/html'
         raise MissingStatusResponse if missing_status_response
 


### PR DESCRIPTION
Adds a little short circuit to enable checking of the static repo's status. Enabled via the new "Host: proxy-version" functionality added to the static nginx proxy (https://github.com/zooniverse/static/pull/420).

Also: updated a couple gems that were installing via git to use published versions and updated nio4r gem explicitly to allow compilation on newer hardware.